### PR TITLE
Corrige cards comunidade

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -314,7 +314,7 @@ section:nth-child(even) .sessao-subtitulo {
   }
 
  .comunidade-conteudo{
-   width: 100%;
+   font-size: 1em;
  } 
 
   .comunidade-conteudo h3 {


### PR DESCRIPTION
Correção dos cards que estavam com visual errado (icone em cima do texto ao invés de estar do lado) em telas maiores que mobile mas menores que full HD, ou seja, entre 1024px (Ipad Pro) e 1920px.