### PR TITLE
Adicionado service worker e manifest.json para portal ser PWA

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,6 +7,7 @@
     <meta name="description" content="Comunidade voltada a incentivar a cultura open source no curso de Ciência da Computação da UFCG." />
     <link rel="stylesheet" href="./css/styles.css" />
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.9.0/css/all.css">
+    <link rel="manifest" href="/manifest.json" />
   </head>
   <body>
 
@@ -136,5 +137,7 @@
     <script src="./data/equipe.js"></script>
     <script src="./js/app.js"></script>
     <script src="./js/typewriter.js"></script>
+    <!-- Must be in the root folder to access the root scope -->
+    <script src="./sw-register.js"></script>
   </body>
 </html>

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "OpenDev UFCG",
+  "name": "OpenDevUFCG",
   "short_name": "OpenDev",
   "start_url": "/",
   "display": "standalone",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,0 +1,13 @@
+{
+  "name": "OpenDev UFCG",
+  "short_name": "OpenDev",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#FFF",
+  "description": "Portal oficial do OpenDev UFCG",
+  "icons": [{
+    "src": "/img/opendev_icon.png",
+    "type": "image/png",
+    "sizes": "192x192 512x512"
+  }]
+}

--- a/docs/service-worker.js
+++ b/docs/service-worker.js
@@ -1,0 +1,26 @@
+(function() {
+  "use-strict";
+
+  // https://developers.google.com/web/tools/workbox
+  importScripts(
+    "https://storage.googleapis.com/workbox-cdn/releases/4.3.1/workbox-sw.js"
+  );
+
+  if (!workbox) return;
+
+  workbox.setConfig({ debug: false })
+
+  // Registro de rota para realizar cache de imagens
+  workbox.routing.registerRoute(
+    /\.(?:png|gif|jpg|jpeg|webp|svg)$/,
+    new workbox.strategies.CacheFirst({
+      cacheName: "images",
+      plugins: [
+        new workbox.expiration.Plugin({
+          maxEntries: 60,
+          maxAgeSeconds: 30 * 24 * 60 * 60 // 30 Days
+        })
+      ]
+    })
+  );
+})();

--- a/docs/sw-register.js
+++ b/docs/sw-register.js
@@ -1,0 +1,16 @@
+if ("serviceWorker" in navigator) {
+  window.addEventListener("load", function() {
+    navigator.serviceWorker.register("/service-worker.js", { scope: "/" }).then(
+      function(registration) {
+        // Registration was successful
+        console.log(
+          `ServiceWorker registration successful with scope: ${registration.scope} ✨`
+        );
+      },
+      function(err) {
+        // registration failed :(
+        console.log("ServiceWorker registration failed: ", err);
+      }
+    );
+  });
+}


### PR DESCRIPTION
Como o título diz, foram adicionados esses arquivos para que o portal possa ser um PWA instalável.

Para isso, precisa seguir determinados [critérios](https://developers.google.com/web/fundamentals/app-install-banners/#criteria) e um deles é registrar um service worker.

P.S.: O service worker foi colocado no mesmo nível do `index.html` e não na pasta `js` pois para que service workers acessem o escopo global, eles devem ser posicionados na pasta mais externa da aplicação.