### PR TITLE
Modifica estrategia de cache de imagens do Service Worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ e esse projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/spec/
 
 ## [Não publicado]
 
+## [1.3.1] - 07/10/2019
+### Corrigido
+- Modifica estratégia de cache de imagens para ser `StaleWhileRevalidate`. 
+
 ## [1.3.0] - 06/10/2019
 ### Adicionado
 - Google Analytics Tracking code.

--- a/docs/service-worker.js
+++ b/docs/service-worker.js
@@ -13,7 +13,7 @@
   // Registro de rota para realizar cache de imagens
   workbox.routing.registerRoute(
     /\.(?:png|gif|jpg|jpeg|webp|svg)$/,
-    new workbox.strategies.CacheFirst({
+    new workbox.strategies.StaleWhileRevalidate({
       cacheName: "images",
       plugins: [
         new workbox.expiration.Plugin({


### PR DESCRIPTION
#### Qual o objetivo dessa Pull Request?
Modifica estrategia de cache de imagens do Service Worker para a **Stale While Revalidate**.

#### Que problema está resolvendo?
Estamos atualizando o site com frequência e o usuário está tendo cache de versões antigas do site. Nessa nova forma o site primeiro puxa do cache, e em background procura se houve novas atualização para renovar o cache.

Obs: Isso vai funcionar pra atualizar a logo do hacktoberfest porque assim que o browser identificar uma nova versão do service worker, ele vai atualizar. Consequentemente o método de pegar imagem vai funcionar

#### Como pode ser manualmente testado?
Teste mudar alguma imagem, e dê um reload para ver se atualiza.

#### Tipos de mudanças
<!-- Marque com x o que se encaixa nas suas mudanças-->

* [x] Conserta um bug
* [x] Nova funcionalidade
* [ ] Refatoração de código
* [ ] Atualiza documentação