### PR TITLE
Altera estrategia de cache para network first

### DIFF
--- a/docs/service-worker.js
+++ b/docs/service-worker.js
@@ -23,4 +23,7 @@
       ]
     })
   );
+  
+  // Default cache
+  workbox.routing.registerRoute(/.*/, new workbox.strategies.NetworkFirst());
 })();


### PR DESCRIPTION
#### Qual o objetivo dessa Pull Request?
alterar a estrategia de cache pra network first

#### Que problema está resolvendo?
Para requests que são atualizadas com frequência, a  estratégia de network first é a solução ideal. Por padrão, ele tentará buscar a resposta mais recente da rede. Se a solicitação for bem-sucedida, ela colocará a resposta no cache. Se a rede falhar em retornar uma resposta, a resposta em cache será usada.
Isso pq nosso site esta passando por muitas modificacoes nos ultimos dias.
Veja mais [aqui](https://developers.google.com/web/tools/workbox/modules/workbox-strategies#network_first_network_falling_back_to_cache)


#### Tipos de mudanças
<!-- Marque com x o que se encaixa nas suas mudanças-->

* [ ] Conserta um bug
* [ ] Nova funcionalidade
* [x] Refatoração de código
* [ ] Atualiza documentação